### PR TITLE
Fixed humidity conversion

### DIFF
--- a/demand_ninja/core.py
+++ b/demand_ninja/core.py
@@ -49,8 +49,8 @@ def _bait(
         + discomfort
         + (
             discomfort
-            # Convert humidity from g/kg to kg/kg
-            * ((weather["humidity"] / 1000) - setpoint_H)
+            # Convert humidity from kg/kg to g/kg
+            * ((weather["humidity"] * 1000) - setpoint_H)
             * humidity_discomfort
         )
     )


### PR DESCRIPTION
The humidity conversion was done in reverse.

The set point is in g/kg, as are the humidity discomfort coefficients (degC/(g/kg)) , so when converting the dataset's specific humidity which is kg/kg, we need to multiply by the factor 1000 not divide

(q)*kg/kg = (q)*(kg/g)*(g/kg)= (q) (1000g/g) (g/kg)= (q*1000) g/kg